### PR TITLE
Use a string literal for the panic message

### DIFF
--- a/lsh-rs/src/lsh/lsh.rs
+++ b/lsh-rs/src/lsh/lsh.rs
@@ -79,7 +79,7 @@ fn lsh_from_lsh<
     let hashers = match ht.store_hashers(&hashers) {
         Ok(_) => hashers,
         Err(_) => match ht.load_hashers() {
-            Err(e) => panic!(format!("could not load hashers: {}", e)),
+            Err(e) => panic!("could not load hashers: {}", e),
             Ok(hashers) => hashers,
         },
     };


### PR DESCRIPTION
Fixes the following compilation error:

```
warning: panic message is not a string literal
  --> /home/orhun/gh/lsh-rs/lsh-rs/src/lsh/lsh.rs:82:30
   |
82 |             Err(e) => panic!(format!("could not load hashers: {}", e)),
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
   = note: the `panic!()` macro supports formatting, so there's no need for the `format!()` macro here
   = note: `#[warn(non_fmt_panics)]` on by default
help: remove the `format!(..)` macro call
   |
82 -             Err(e) => panic!(format!("could not load hashers: {}", e)),
82 +             Err(e) => panic!("could not load hashers: {}", e),
   |

warning: `lsh-rs` (lib) generated 1 warning (run `cargo fix --lib -p lsh-rs` to apply 1 suggestion)
```
